### PR TITLE
Add _version_helper.py to manifest

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,6 @@
 README
 setup.py
+_version_helper.py
 autoslug/__init__.py
 autoslug/fields.py
 autoslug/settings.py


### PR DESCRIPTION
Fix installation from PyPy.

The first step to fix [#43](https://bitbucket.org/neithere/django-autoslug/issues/43/importerror-no-module-named).