### PR TITLE
Add allow_unicode attribute for django 1.9 compatibility.

### DIFF
--- a/autoslug/fields.py
+++ b/autoslug/fields.py
@@ -200,6 +200,10 @@ class AutoSlugField(SlugField):
         if 'db_index' not in kwargs:
             kwargs['db_index'] = True
 
+        # A boolean instructing the field to accept Unicode letters in
+        # addition to ASCII letters. Defaults to False.
+        self.allow_unicode = kwargs.pop('allow_unicode', False)
+
         # When using model inheritence, set manager to search for matching
         # slug values
         self.manager = kwargs.pop('manager', None)


### PR DESCRIPTION
Please add the allow_unicode attribute to AutoSlugField for django 1.9 future compatibility.

See : https://django.readthedocs.org/en/latest/ref/forms/fields.html#django.forms.SlugField.allow_unicode

Thanks.