### PR TITLE
Don't override manager if it's in the arguments.

### DIFF
--- a/autoslug/fields.py
+++ b/autoslug/fields.py
@@ -244,6 +244,9 @@ class AutoSlugField(SlugField):
         if self.always_update:
             kwargs['always_update'] = self.always_update
 
+        if 'manager' in kwargs:
+            del kwargs['manager']
+
         return name, path, args, kwargs
 
     def pre_save(self, instance, add):

--- a/autoslug/tests/tests.py
+++ b/autoslug/tests/tests.py
@@ -241,6 +241,12 @@ class AutoSlugFieldTestCase(TestCase):
         b = NonDeletableModelWithUniqueSlug.objects.create(name='My name')
         self.assertEqual(b.slug, u'my-name-2')
 
+    def test_deconstruct_with_manager(self):
+        a = SharedSlugSpace(name='TestName')
+        a.save()
+        _, _, _, kwargs = a._meta.get_field('slug').deconstruct()
+        self.assertNotIn('manager', kwargs)
+
 
 class AutoSlugModelTranslationTestCase(TestCase):
 


### PR DESCRIPTION
Fixes: https://bitbucket.org/neithere/django-autoslug/issues/34/django-migrations-fail-i