### PR TITLE
Django 1.10 compatibility

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,4 +31,5 @@ generally made django-autoslug better:
 * kane-c
 * Julien Dubiel
 * Tony Shtarev
+* Éloi Rivard
 * Your Name Here ;)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Version 1.9.4-dev
 New features:
 
 - Add `manager_name` kwarg to enable using custom managers from abstract models.
+- Django 1.10 compatibility.
 
 Version 1.9.3
 -------------

--- a/autoslug/settings.py
+++ b/autoslug/settings.py
@@ -58,7 +58,7 @@ Django settings that affect django-autoslug:
 
 """
 from django.conf import settings
-from django.core.urlresolvers import get_callable
+from django.urls import get_callable
 
 # use custom slugifying function if any
 slugify_function_path = getattr(settings, 'AUTOSLUG_SLUGIFY_FUNCTION', 'autoslug.utils.slugify')

--- a/autoslug/settings.py
+++ b/autoslug/settings.py
@@ -58,7 +58,7 @@ Django settings that affect django-autoslug:
 
 """
 from django.conf import settings
-from django.urls import get_callable
+from django.core.urlresolvers import get_callable
 
 # use custom slugifying function if any
 slugify_function_path = getattr(settings, 'AUTOSLUG_SLUGIFY_FUNCTION', 'autoslug.utils.slugify')

--- a/autoslug/tests/models.py
+++ b/autoslug/tests/models.py
@@ -1,4 +1,4 @@
-from django.db.models import Model, CharField, DateField, BooleanField, ForeignKey, Manager
+from django.db.models import Model, CharField, DateField, BooleanField, ForeignKey, Manager, CASCADE
 
 
 # this app
@@ -18,7 +18,7 @@ class ModelWithUniqueSlug(Model):
 
 class ModelWithUniqueSlugFK(Model):
     name = CharField(max_length=200)
-    simple_model = ForeignKey(SimpleModel)
+    simple_model = ForeignKey(SimpleModel, on_delete=CASCADE)
     slug = AutoSlugField(populate_from='name', unique_with='simple_model__name')
 
 
@@ -138,7 +138,7 @@ class ModelWithSlugSpaceShared(SharedSlugSpace):
 
 class ModelWithUniqueSlugFKNull(Model):
     name = CharField(max_length=200)
-    simple_model = ForeignKey(SimpleModel, null=True, blank=True, default=None)
+    simple_model = ForeignKey(SimpleModel, null=True, blank=True, default=None, on_delete=CASCADE)
     slug = AutoSlugField(populate_from='name', unique_with='simple_model')
 
 

--- a/autoslug/utils.py
+++ b/autoslug/utils.py
@@ -116,7 +116,7 @@ def get_uniqueness_lookups(field, instance, unique_with):
         value = getattr(instance, field_name)
         if not value:
             if other_field.blank:
-                field_object, model, direct, m2m = instance._meta.get_field_by_name(field_name)
+                field_object = instance._meta.get_field(field_name)
                 if isinstance(field_object, ForeignKey):
                     lookup = '%s__isnull' % field_name
                     yield lookup, True


### PR DESCRIPTION
Hi.
This PR bring django 1.10 compatibility. There was just one uncompatible function ([get_field_by_name](https://docs.djangoproject.com/en/1.10/ref/models/meta/#migrating-from-the-old-api)).

Also with django 1.10, running tests with `python -Wall run_tests.py` show some django 2.0 deprecations that are also fixed. `on_delete` parameter [will become mandatory](https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.ForeignKey). So I explicitely set the default value, that is `CASCADE`.

There is still a django 2.0 deprecation that I did not remove. Replacing imports from `django.core.urlresolvers` by `django.urls` would break 1.7 compatibility.
https://docs.djangoproject.com/en/1.10/ref/urlresolvers/

@neithere, what do you think?