### PR TITLE
Supress urlresolvers warning

### DIFF
--- a/autoslug/settings.py
+++ b/autoslug/settings.py
@@ -58,12 +58,10 @@ Django settings that affect django-autoslug:
 
 """
 from django.conf import settings
-from django import VERSION
-
-if VERSION >= (2, 0):
-    from django.urls import get_callable
-else:
-    from django.core.urlresolvers import get_callable
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 
 # use custom slugifying function if any
 slugify_function_path = getattr(settings, 'AUTOSLUG_SLUGIFY_FUNCTION', 'autoslug.utils.slugify')


### PR DESCRIPTION
Tell don't ask.

This supress the warning on Django versions who alrady provide the class (Like Django >=1.10)