### PR TITLE
Fix transliteration and add types

### DIFF
--- a/autoslug/tests/models.py
+++ b/autoslug/tests/models.py
@@ -172,7 +172,7 @@ class AbstractModelWithCustomManager(Model):
     class Meta:
         abstract = True
 
-    def delete(self, using=None):
+    def delete(self, **kwargs):
         self.is_deleted = True
         self.save()
 

--- a/autoslug/utils.py
+++ b/autoslug/utils.py
@@ -20,7 +20,7 @@ from django.template.defaultfilters import slugify as django_slugify
 from django.utils.timezone import localtime, is_aware
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Callable, Generator, Sequence
     from django.db.models import SlugField, Model, Manager
     from django.db.models.base import Options

--- a/requirements/devel.txt
+++ b/requirements/devel.txt
@@ -1,1 +1,1 @@
-coverage==5.0.3
+coverage==7.3.2

--- a/run_tests.py
+++ b/run_tests.py
@@ -28,6 +28,7 @@ conf = dict(
         ),
     ),
     AUTOSLUG_SLUGIFY_FUNCTION = 'django.template.defaultfilters.slugify',
+    DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 )
 
 


### PR DESCRIPTION
Transliteration was still in python2 mode and never upgraded. Since this module should no longer support python 2.x rewrite it to python 3.

Python 3's join() doesn't allow you to combine bytes and str, so we have to encode the delimiter as well.

Last but not least, document how translitcodec works, so we don't have to find this out the hard way.

Also type this module.
Utils are only used internally, but type them anyway as they can be referenced trough dotted notation in settings or people may import and use some of the functions here.

Chores:
- Silence warnings on test runs
- Upgrade coverage and no cover TYPE_CHECKING branch